### PR TITLE
Aplica lógicas diferentes para o create e para o update plano de trabalho

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -114,3 +114,22 @@ class PlanoTrabalhoSchema(BaseModel):
 
     class Config:
         orm_mode = True
+
+class PlanoTrabalhoUpdateSchema(BaseModel):
+    """Esquema para atualização do plano de trabalho. Na atualização,
+    todos os campos são opcionais, exceto cod_plano."""
+    cod_plano: str
+    matricula_siape: Optional[int]
+    cpf: Optional[str]
+    nome_participante: Optional[str]
+    cod_unidade_exercicio: Optional[int]
+    nome_unidade_exercicio: Optional[str]
+    modalidade_execucao: ModalidadeEnum = Field(None, alias='modalidade_execucao')
+    carga_horaria_semanal: Optional[int]
+    data_inicio: Optional[date]
+    data_fim: Optional[date]
+    carga_horaria_total: Optional[float]
+    data_interrupcao: Optional[date]
+    entregue_no_prazo: Optional[bool] = None
+    horas_homologadas: Optional[float]
+    atividades: List[AtividadeSchema] # = []

--- a/schemas.py
+++ b/schemas.py
@@ -33,7 +33,7 @@ class PlanoTrabalhoSchema(BaseModel):
     nome_participante: str
     cod_unidade_exercicio: int
     nome_unidade_exercicio: str
-    modalidade_execucao: ModalidadeEnum = Field(None, alias='modalidade_execucao')
+    modalidade_execucao: ModalidadeEnum = Field(..., alias='modalidade_execucao')
     carga_horaria_semanal: int
     data_inicio: date
     data_fim: date

--- a/test_api.py
+++ b/test_api.py
@@ -375,6 +375,39 @@ def test_create_plano_trabalho_missing_mandatory_fields(input_pt: dict,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+@pytest.mark.parametrize("missing_fields",
+                         (
+                             ["matricula_siape"],
+                             ["cpf"],
+                             ["nome_participante"],
+                             ["cod_unidade_exercicio"],
+                             ["nome_unidade_exercicio"],
+                             ["modalidade_execucao"],
+                             ["carga_horaria_semanal"],
+                             ["data_inicio"],
+                             ["data_fim"],
+                             ["carga_horaria_total"],
+                         ))
+def test_update_plano_trabalho_missing_mandatory_fields(input_pt: dict,
+                                             missing_fields: list,
+                                             header_usr_1: dict,
+                                             truncate_pt,
+                                             client: Session):
+    """Tenta atualizar um plano de trabalho, faltando campos
+    obrigatórios. Tem que ser um plano de trabalho existente para ser
+    interpretado como update. O campo que ficar faltando será
+    interpretado como um campo que não será atualizado, ainda que seja
+    obrigatório no momento de sua criação.
+    """
+    for field in missing_fields:
+        del input_pt[field]
+
+    input_pt['cod_plano'] = 1800
+    response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
+                          json=input_pt,
+                          headers=header_usr_1)
+    assert response.status_code == status.HTTP_200_OK
+
 def test_create_pt_cod_plano_inconsistent(input_pt: dict,
                                           header_usr_1: dict,
                                           truncate_pt,

--- a/test_api.py
+++ b/test_api.py
@@ -321,21 +321,22 @@ def test_create_plano_trabalho_completo(input_pt: dict,
     assert response.json() == input_pt
 
 @pytest.mark.parametrize("omitted_fields",
-                         [
-                             (["data_interrupcao"]),
-                             (["data_interrupcao", "entregue_no_prazo"]),
-                             (["entregue_no_prazo"]),
-                         ])
+                         enumerate((
+                             ["data_interrupcao"],
+                             ["data_interrupcao", "entregue_no_prazo"],
+                             ["entregue_no_prazo"],
+                         )))
 def test_create_plano_trabalho_omit_optional_fields(input_pt: dict,
                                              omitted_fields: list,
                                              header_usr_1: dict,
                                              truncate_pt,
                                              client: Session):
-    for field in omitted_fields:
+    offset, field_list = omitted_fields
+    for field in field_list:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 557
-    response = client.put(f"/plano_trabalho/557",
+    input_pt['cod_plano'] = 557 + offset
+    response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK

--- a/test_api.py
+++ b/test_api.py
@@ -326,7 +326,7 @@ def test_create_plano_trabalho_completo(input_pt: dict,
                              (["data_interrupcao", "entregue_no_prazo"]),
                              (["entregue_no_prazo"]),
                          ])
-def test_create_plano_trabalho_omit_optional_fileds(input_pt: dict,
+def test_create_plano_trabalho_omit_optional_fields(input_pt: dict,
                                              omitted_fields: list,
                                              header_usr_1: dict,
                                              truncate_pt,
@@ -341,19 +341,19 @@ def test_create_plano_trabalho_omit_optional_fileds(input_pt: dict,
     assert response.status_code == status.HTTP_200_OK
 
 @pytest.mark.parametrize("missing_fields",
-                         [
-                             (["matricula_siape"]),
-                             (["cpf"]),
-                             (["nome_participante"]),
-                             (["cod_unidade_exercicio"]),
-                             (["nome_unidade_exercicio"]),
-                             (["modalidade_execucao"]),
-                             (["carga_horaria_semanal"]),
-                             (["data_inicio"]),
-                             (["data_fim"]),
-                             (["carga_horaria_total"]),
-                         ])
-def test_create_plano_trabalho_missing_mandatory_fileds(input_pt: dict,
+                         enumerate((
+                             ["matricula_siape"],
+                             ["cpf"],
+                             ["nome_participante"],
+                             ["cod_unidade_exercicio"],
+                             ["nome_unidade_exercicio"],
+                             ["modalidade_execucao"],
+                             ["carga_horaria_semanal"],
+                             ["data_inicio"],
+                             ["data_fim"],
+                             ["carga_horaria_total"],
+                         )))
+def test_create_plano_trabalho_missing_mandatory_fields(input_pt: dict,
                                              missing_fields: list,
                                              header_usr_1: dict,
                                              truncate_pt,
@@ -364,11 +364,12 @@ def test_create_plano_trabalho_missing_mandatory_fileds(input_pt: dict,
     interpretado como um campo que não será atualizado, ainda que seja
     obrigatório para a criação.
     """
-    for field in missing_fields:
+    offset, field_list = missing_fields
+    for field in field_list:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 1801 # precisa ser um novo plano
-    response = client.put(f"/plano_trabalho/1801",
+    input_pt['cod_plano'] = 1800 + offset # precisa ser um novo plano
+    response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Ao fazer PUT `/plano_trabalho/{cod_plano}`, aplicar comportamentos diferentes. Caso não exista no banco, será um *create*. Caso não exista, será um *update*. No *create*, devem ser passados os parâmetros obrigatórios. No *update*, eles podem ser omitidos: nesse caso, eles não serão alterados pelo *update*.

Considerar, no futuro, mudar esse comportamento de update parcial para o verbo PATCH, e deixar o PUT apenas para update com os dados completos.