### PR TITLE
fixes #7 separa a funcionalidade do PUT e PATCH

### DIFF
--- a/api.py
+++ b/api.py
@@ -121,6 +121,8 @@ async def create_or_update_plano_trabalho(
     token: str = Depends(oauth2_scheme),
     user: User = Depends(fastapi_users.current_user(active=True))
     ):
+    """Cria um novo plano de trabalho ou, se existente, substitui um
+    plano de trabalho por um novo com os dados informados."""
     # Validações da entrada conforme regras de negócio
     if cod_plano != plano_trabalho.cod_plano:
         raise HTTPException(
@@ -160,6 +162,7 @@ async def patch_plano_trabalho(
     token: str = Depends(oauth2_scheme),
     user: User = Depends(fastapi_users.current_user(active=True))
     ):
+    "Atualiza um plano de trabalho existente nos campos informados."
     # Validações da entrada conforme regras de negócio
     if cod_plano != plano_trabalho.cod_plano:
         raise HTTPException(

--- a/api.py
+++ b/api.py
@@ -112,8 +112,9 @@ async def shutdown():
     await auth_db.disconnect()
 
 @app.put("/plano_trabalho/{cod_plano}",
-         response_model=schemas.PlanoTrabalhoSchema
-         )
+        summary="Cria ou substitui plano de trabalho",
+        response_model=schemas.PlanoTrabalhoSchema
+        )
 async def create_or_update_plano_trabalho(
     cod_plano: str,
     plano_trabalho: schemas.PlanoTrabalhoSchema,
@@ -153,8 +154,9 @@ async def create_or_update_plano_trabalho(
     return plano_trabalho
 
 @app.patch("/plano_trabalho/{cod_plano}",
-         response_model=schemas.PlanoTrabalhoSchema
-         )
+        summary="Atualiza plano de trabalho",
+        response_model=schemas.PlanoTrabalhoSchema
+        )
 async def patch_plano_trabalho(
     cod_plano: str,
     plano_trabalho: schemas.PlanoTrabalhoUpdateSchema,
@@ -200,13 +202,15 @@ async def patch_plano_trabalho(
                         " de outra unidade.")
 
 @app.get("/plano_trabalho/{cod_plano}",
-         response_model=schemas.PlanoTrabalhoSchema
+        summary="Consulta plano de trabalho",
+        response_model=schemas.PlanoTrabalhoSchema
         )
 async def get_plano_trabalho(cod_plano: str,
                        db: Session = Depends(get_db),
                        token: str = Depends(oauth2_scheme),
                     #    user: User = Depends(fastapi_users.current_user())
                        ):
+    "Consulta o plano de trabalho com o código especificado."
     db_plano_trabalho = crud.get_plano_trabalho(db, cod_plano)
     if db_plano_trabalho is None:
         raise HTTPException(404, detail="Plano de trabalho não encontrado")

--- a/schemas.py
+++ b/schemas.py
@@ -4,7 +4,7 @@ from datetime import date
 from enum import IntEnum
 
 class AtividadeSchema(BaseModel):
-    id_atividade: int
+    id_atividade: int = Field(title='id da atividade')
     nome_grupo_atividade: Optional[str]
     nome_atividade: str
     faixa_complexidade: str
@@ -27,9 +27,13 @@ class ModalidadeEnum(IntEnum):
     teletrabalho = 3
 
 class PlanoTrabalhoSchema(BaseModel):
-    cod_plano: str
-    matricula_siape: int
-    cpf: str
+    cod_plano: str = Field(title='código do plano')
+    matricula_siape: int = Field(title='Matrícula SIAPE')
+    cpf: str = Field(
+        title='CPF',
+        description='Cadastro da pessoa física na Receita Federal do Brasil.\n'
+            '\n'
+            'Deve conter apenas dígitos.')
     nome_participante: str
     cod_unidade_exercicio: int
     nome_unidade_exercicio: str


### PR DESCRIPTION
PUT é para o recurso completo; PATCH pode ser uma atualização parcial, enviando apenas os campos que serão alterados.

Já está implementado e com testes. Se concordar com esse requisito, é só aceitar o PR.