### PR TITLE
testes e implementação para campos opcionais e obrigatórios de atividades

### DIFF
--- a/admin_tool.py
+++ b/admin_tool.py
@@ -37,31 +37,31 @@ def list_users(connection: sa.engine.Connection, cod_unidade: int = None):
     Caso seja omitido, mostra os usuários de todas as unidades.
     """
     if cod_unidade is None:
-        result = connection.execute('select count(*) from public.user')
+        result = connection.execute("select count(*) from public.user")
     else:
         result = connection.execute(
-            'select count(*) from public.user where '
+            "select count(*) from public.user where "
             f"cod_unidade='{cod_unidade}'"
         )
     user_quantity = result.scalar()
     if user_quantity < 1:
         print(
-            'Não há usuários cadastrados' +
-            (f' na unidade {cod_unidade}' if cod_unidade is not None else '') +
-            '.'
+            "Não há usuários cadastrados" +
+            (f" na unidade {cod_unidade}" if cod_unidade is not None else "") +
+            "."
         )
         return
-    plural = 's' if user_quantity > 1 else ''
+    plural = "s" if user_quantity > 1 else ""
     print (
-        f'Há {user_quantity} usuário{plural} cadastrado{plural}' +
-        (f' na unidade {cod_unidade}' if cod_unidade is not None else '') +
-        ': \n'
+        f"Há {user_quantity} usuário{plural} cadastrado{plural}" +
+        (f" na unidade {cod_unidade}" if cod_unidade is not None else "") +
+        ": \n"
     )
     if cod_unidade is None:
-        result = connection.execute('select * from public.user')
+        result = connection.execute("select * from public.user")
     else:
         result = connection.execute(
-            'select * from public.user where '
+            "select * from public.user where "
             f"cod_unidade='{cod_unidade}'"
         )
     for row in result:
@@ -75,38 +75,38 @@ def list_users(connection: sa.engine.Connection, cod_unidade: int = None):
 def grant_superuser(connection: sa.engine.Connection, email: str):
     " Dá permissão de superusuário ao usuário com o e-mail especificado."
     # precaução contra injection
-    email = email.replace('"', '').replace("'", "")
+    email = email.replace('"', "").replace("'", "")
     user = connection.execute(
         f"select * from public.user where email='{email}'"
     ).fetchone()
     if user is None:
-        print(f'Nenhum usuário não encontrado com o e-mail {email}')
+        print(f"Nenhum usuário não encontrado com o e-mail {email}")
         return
-    if user['is_superuser']:
-        print(f'Usuário com o e-mail {email} já é superusuário.')
+    if user["is_superuser"]:
+        print(f"Usuário com o e-mail {email} já é superusuário.")
     result = connection.execute(
-        'update public.user set is_superuser=true '
+        "update public.user set is_superuser=true "
         f"WHERE id='{user['id']}'"
     )
     if not result:
-        raise IOError ('Erro ao gravar no banco de dados.')
+        raise IOError ("Erro ao gravar no banco de dados.")
     print(
-        'Permissão de superusuário concedida ao usuário '
-        f'com o e-mail {email}.'
+        "Permissão de superusuário concedida ao usuário "
+        f"com o e-mail {email}."
     )
 
 async def create_superuser(fastapi_users: FastAPIUsers):
     " Cria um novo superusuário."
-    print(' Preencha os dados do usuário:\n')
-    email = input('  e-mail: ') 
-    cod_unidade = input ('  código da unidade: ')
+    print(" Preencha os dados do usuário:\n")
+    email = input("  e-mail: ") 
+    cod_unidade = input ("  código da unidade: ")
     # TODO: parametrizar abaixo
-    # password = getpass.getpass(prompt='  senha: ')
-    # confirm_password = getpass.getpass(prompt='  confirmação da senha: ')
-    password = input('  senha: ')
-    confirm_password = input('  confirmação da senha: ')
+    # password = getpass.getpass(prompt="  senha: ")
+    # confirm_password = getpass.getpass(prompt="  confirmação da senha: ")
+    password = input("  senha: ")
+    confirm_password = input("  confirmação da senha: ")
     if password != confirm_password:
-        raise ValueError('As senhas informadas são diferentes.')
+        raise ValueError("As senhas informadas são diferentes.")
     
     await database_meta.connect()
     superuser = await fastapi_users.create_user(
@@ -119,42 +119,42 @@ async def create_superuser(fastapi_users: FastAPIUsers):
     )
     await database_meta.disconnect()
     if not superuser:
-        raise IOError ('Erro ao gravar no banco de dados.')
+        raise IOError ("Erro ao gravar no banco de dados.")
 
 async def truncate_users(connection: sa.engine.Connection):
     " Expurga todos os usuários do banco de dados."
-    connection.execute(sa_text('TRUNCATE TABLE "user"'))
+    connection.execute(sa_text("TRUNCATE TABLE 'user'"))
     print("Tabela de usuários truncada.")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__
     )
     parser.add_argument(
-        '--list_users',
+        "--list_users",
         help=list_users.__doc__,
-        nargs='?',
+        nargs="?",
         const=True, # valor quando se usa o argumento sem COD_UNIDADE
-        metavar='COD_UNIDADE'
+        metavar="COD_UNIDADE"
     )
     parser.add_argument(
-        '--grant_superuser',
+        "--grant_superuser",
         help=grant_superuser.__doc__,
         nargs=1,
-        metavar='USER_EMAIL'
+        metavar="USER_EMAIL"
     )
     parser.add_argument(
-        '--create_superuser',
+        "--create_superuser",
         help=create_superuser.__doc__,
-        action='store_true'
+        action="store_true"
     )
     parser.add_argument(
-        '--truncate-users',
+        "--truncate-users",
         help=truncate_users.__doc__,
-        action='store_true'
+        action="store_true"
     )
 
-    engine = sa.create_engine('postgresql://postgres:postgres@db-api-pgd:5432/api_pgd')
+    engine = sa.create_engine("postgresql://postgres:postgres@db-api-pgd:5432/api_pgd")
 
     args = parser.parse_args()
 

--- a/api.py
+++ b/api.py
@@ -179,6 +179,7 @@ async def patch_plano_trabalho(
                         " existente.")
     else: # patch
         if db_plano_trabalho.cod_unidade == user.cod_unidade:
+            # TODO: fazer passar testes faltando atividade
             try:
                 merged_plano_trabalho = {
                     k: v

--- a/api.py
+++ b/api.py
@@ -10,7 +10,7 @@ from fastapi_users import FastAPIUsers
 from fastapi_users.authentication import JWTAuthentication
 from fastapi.openapi.utils import get_openapi
 
-import models, schemas, crud
+import models, schemas, crud, util
 from database import engine, get_db
 from auth import user_db, User, UserCreate, UserUpdate, UserDB, SECRET_KEY
 from auth import database_meta as auth_db
@@ -177,30 +177,60 @@ async def patch_plano_trabalho(
                 status.HTTP_404_NOT_FOUND,
                 detail="Só é possível aplicar PATCH em um recurso"+
                         " existente.")
-    else: # patch
-        if db_plano_trabalho.cod_unidade == user.cod_unidade:
-            # TODO: fazer passar testes faltando atividade
-            try:
-                merged_plano_trabalho = {
-                    k: v
-                    for k, v in db_plano_trabalho.__dict__.items()
-                    if k[0] != '_'
-                }
-                merged_plano_trabalho.update(
-                    plano_trabalho.dict(exclude_unset=True))
-                schemas.PlanoTrabalhoSchema(**merged_plano_trabalho)
-            except ValidationError as e:
-                raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=json.loads(e.json())
-            )
-            crud.update_plano_tabalho(db, plano_trabalho)
-            return merged_plano_trabalho
-        else:
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN,
-                detail="Usuário não pode alterar Plano de Trabalho"+
-                        " de outra unidade.")
+    if db_plano_trabalho.cod_unidade != user.cod_unidade:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="Usuário não pode alterar Plano de Trabalho"+
+                    " de outra unidade.")
+    
+    # atualiza os atributos, exceto atividades
+    merged_plano_trabalho = util.sa_obj_to_dict(db_plano_trabalho)
+    patch_plano_trabalho = plano_trabalho.dict(exclude_unset=True)
+    if patch_plano_trabalho.get('atividades', None):
+        del patch_plano_trabalho['atividades']
+    merged_plano_trabalho.update(patch_plano_trabalho)
+
+    # atualiza as atividades
+
+    # traz a lista de atividade que está no banco
+    db_atividades = util.list_to_dict(
+        [
+            util.sa_obj_to_dict(atividade)
+            for atividade in getattr(db_plano_trabalho, 'atividades',
+                                                    list())
+        ],
+        'id_atividade'
+    )
+
+    # cada atividade a ser modificada
+    patch_atividades = util.list_to_dict(
+        plano_trabalho.dict(exclude_unset=True).get('atividades', list()),
+        'id_atividade'
+    )
+
+    merged_atividades = util.merge_dicts(db_atividades, patch_atividades)
+    merged_plano_trabalho['atividades'] = util.dict_to_list(
+        merged_atividades,
+        'id_atividade'
+    )
+
+    # tenta validar o esquema
+
+    # para validar o esquema, é necessário ter o atributo atividades,
+    # mesmo que seja uma lista vazia
+    if merged_plano_trabalho.get('atividades', None) is None:
+        merged_plano_trabalho['atividades'] = []
+    # valida o esquema do plano de trabalho atualizado
+    try:
+        schemas.PlanoTrabalhoSchema(**merged_plano_trabalho)
+    except ValidationError as e:
+        raise HTTPException(
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=json.loads(e.json())
+    )
+    
+    crud.update_plano_tabalho(db, plano_trabalho)
+    return merged_plano_trabalho
 
 @app.get("/plano_trabalho/{cod_plano}",
         summary="Consulta plano de trabalho",

--- a/api.py
+++ b/api.py
@@ -186,8 +186,8 @@ async def patch_plano_trabalho(
     # atualiza os atributos, exceto atividades
     merged_plano_trabalho = util.sa_obj_to_dict(db_plano_trabalho)
     patch_plano_trabalho = plano_trabalho.dict(exclude_unset=True)
-    if patch_plano_trabalho.get('atividades', None):
-        del patch_plano_trabalho['atividades']
+    if patch_plano_trabalho.get("atividades", None):
+        del patch_plano_trabalho["atividades"]
     merged_plano_trabalho.update(patch_plano_trabalho)
 
     # atualiza as atividades
@@ -196,30 +196,30 @@ async def patch_plano_trabalho(
     db_atividades = util.list_to_dict(
         [
             util.sa_obj_to_dict(atividade)
-            for atividade in getattr(db_plano_trabalho, 'atividades',
+            for atividade in getattr(db_plano_trabalho, "atividades",
                                                     list())
         ],
-        'id_atividade'
+        "id_atividade"
     )
 
     # cada atividade a ser modificada
     patch_atividades = util.list_to_dict(
-        plano_trabalho.dict(exclude_unset=True).get('atividades', list()),
-        'id_atividade'
+        plano_trabalho.dict(exclude_unset=True).get("atividades", list()),
+        "id_atividade"
     )
 
     merged_atividades = util.merge_dicts(db_atividades, patch_atividades)
-    merged_plano_trabalho['atividades'] = util.dict_to_list(
+    merged_plano_trabalho["atividades"] = util.dict_to_list(
         merged_atividades,
-        'id_atividade'
+        "id_atividade"
     )
 
     # tenta validar o esquema
 
     # para validar o esquema, é necessário ter o atributo atividades,
     # mesmo que seja uma lista vazia
-    if merged_plano_trabalho.get('atividades', None) is None:
-        merged_plano_trabalho['atividades'] = []
+    if merged_plano_trabalho.get("atividades", None) is None:
+        merged_plano_trabalho["atividades"] = []
     # valida o esquema do plano de trabalho atualizado
     try:
         schemas.PlanoTrabalhoSchema(**merged_plano_trabalho)
@@ -270,9 +270,9 @@ def public_facing_openapi():
         version = app.version,
         routes = app.routes
     )
-    paths = openapi_schema['paths']
-    del paths['/truncate_pts_atividades']
-    del paths['/users/{id}']
+    paths = openapi_schema["paths"]
+    del paths["/truncate_pts_atividades"]
+    del paths["/users/{id}"]
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 

--- a/auth.py
+++ b/auth.py
@@ -18,7 +18,7 @@ from database import SessionLocal, engine, SQLALCHEMY_DATABASE_URL
 
 # to get a string like this run:
 # openssl rand -hex 32
-SECRET_KEY = 'e6eecfcf4d966355276ce17554fb58bf0674b20963843d58a4670a85d98e6e2c'
+SECRET_KEY = "e6eecfcf4d966355276ce17554fb58bf0674b20963843d58a4670a85d98e6e2c"
 ALGORITHM = "HS256"
 
 fake_users_db = {
@@ -57,7 +57,7 @@ class UserUpdate(User, user_models.BaseUserUpdate):
         if p is not None:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                detail=f'Não tem permissão para alterar o atributo.')
+                detail=f"Não tem permissão para alterar o atributo.")
         return d
 
 class UserDB(User, user_models.BaseUserDB):

--- a/crud.py
+++ b/crud.py
@@ -51,7 +51,7 @@ def update_plano_tabalho(
     )
     # db_plano_trabalho.cod_unidade = cod_unidade
     for k, v in plano_trabalho.__dict__.items():
-        if k[0] != '_' and k != 'atividades':
+        if k[0] != "_" and k != "atividades":
             setattr(db_plano_trabalho, k, getattr(plano_trabalho, k))
     # db_atividades = [models.Atividade(**a.dict()) for a in plano_trabalho.atividades]
     # db_plano_trabalho.atividades = db_atividades
@@ -63,5 +63,5 @@ def update_plano_tabalho(
 
 def truncate_pts_atividades(db: Session):
     "Trunca as tabelas principais. Útil para zerar BD para executar testes."
-    db.execute(sa_text('TRUNCATE TABLE plano_trabalho CASCADE'))
+    db.execute(sa_text("TRUNCATE TABLE plano_trabalho CASCADE"))
     db.commit()

--- a/database.py
+++ b/database.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = 'postgresql://postgres:postgres@db-api-pgd:5432/api_pgd'
+SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@db-api-pgd:5432/api_pgd"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/models.py
+++ b/models.py
@@ -10,7 +10,7 @@ from database import Base
 
 class PlanoTrabalho(Base):
     "Plano de Trabalho"
-    __tablename__ = 'plano_trabalho'
+    __tablename__ = "plano_trabalho"
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     cod_unidade = Column(Integer, nullable=False)
     cod_plano = Column(String, nullable=False)
@@ -27,19 +27,19 @@ class PlanoTrabalho(Base):
     data_interrupcao = Column(Date)
     entregue_no_prazo = Column(Boolean) #TODO Na especificação está como Int e usa 1 e 2 para sim e não. Não seria melhor usar bool?
     horas_homologadas = Column(Float)
-    atividades = relationship('Atividade', back_populates='plano_trabalho')
+    atividades = relationship("Atividade", back_populates="plano_trabalho")
     __table_args__ = (UniqueConstraint(
-        'cod_unidade',
-        'cod_plano',
-        name='_unidade_plano_uc'
+        "cod_unidade",
+        "cod_plano",
+        name="_unidade_plano_uc"
     ),)
 
 class Atividade(Base):
     "Atividade"
-    __tablename__ = 'atividade'
+    __tablename__ = "atividade"
     # id_atividade = Column(Integer, primary_key=True, index=True)
     cod_unidade = Column(Integer, primary_key=True, index=True)
-    id_plano_trabalho = Column(Integer, ForeignKey('plano_trabalho.id'), primary_key=True, index=True)
+    id_plano_trabalho = Column(Integer, ForeignKey("plano_trabalho.id"), primary_key=True, index=True)
     id_atividade = Column(Integer, primary_key=True, index=True)
     nome_grupo_atividade = Column(String)
     nome_atividade = Column(String)
@@ -53,4 +53,4 @@ class Atividade(Base):
     avaliacao = Column(Integer)
     data_avaliacao = Column(Date)
     justificativa = Column(String)
-    plano_trabalho = relationship('PlanoTrabalho', back_populates='atividades')
+    plano_trabalho = relationship("PlanoTrabalho", back_populates="atividades")

--- a/schemas.py
+++ b/schemas.py
@@ -119,6 +119,21 @@ class PlanoTrabalhoSchema(BaseModel):
     class Config:
         orm_mode = True
 
+class AtividadeUpdateSchema(BaseModel):
+    id_atividade: int = Field(title='id da atividade')
+    nome_grupo_atividade: Optional[str]
+    nome_atividade: Optional[str]
+    faixa_complexidade: Optional[str]
+    parametros_complexidade: Optional[str]
+    tempo_exec_presencial: Optional[float]
+    tempo_exec_teletrabalho: Optional[float]
+    entrega_esperada: Optional[str]
+    qtde_entregas: Optional[int]
+    qtde_entregas_efetivas: Optional[int]
+    avaliacao: Optional[int]
+    data_avaliacao: Optional[date]
+    justificativa: Optional[str]
+    
 class PlanoTrabalhoUpdateSchema(BaseModel):
     """Esquema para atualização do plano de trabalho. Na atualização,
     todos os campos são opcionais, exceto cod_plano."""
@@ -136,4 +151,4 @@ class PlanoTrabalhoUpdateSchema(BaseModel):
     data_interrupcao: Optional[date]
     entregue_no_prazo: Optional[bool] = None
     horas_homologadas: Optional[float]
-    atividades: List[AtividadeSchema] # = []
+    atividades: Optional[List[AtividadeUpdateSchema]] # = []

--- a/schemas.py
+++ b/schemas.py
@@ -52,13 +52,14 @@ class PlanoTrabalhoSchema(BaseModel):
     def data_validate(cls, values):
         data_inicio = values.get('data_inicio', None)
         data_fim = values.get('data_fim', None)
-        atividades = values.get('atividades')[0]
         if data_inicio > data_fim:
             raise ValueError("Data fim do Plano de Trabalho deve ser maior" \
                      " ou igual que Data início.")
-        if data_fim > atividades.data_avaliacao:
-            raise ValueError("Data de avaliação da atividade deve ser maior ou igual" \
-                     " que a Data Fim do Plano de Trabalho.")
+        for atividade in values.get('atividades', []):
+            if getattr(atividade, 'data_avaliacao', None) is not None and \
+                data_fim > atividade.data_avaliacao:
+                    raise ValueError("Data de avaliação da atividade deve ser maior ou igual" \
+                        " que a Data Fim do Plano de Trabalho.")
         return values
 
     @root_validator
@@ -133,7 +134,7 @@ class AtividadeUpdateSchema(BaseModel):
     avaliacao: Optional[int]
     data_avaliacao: Optional[date]
     justificativa: Optional[str]
-    
+
 class PlanoTrabalhoUpdateSchema(BaseModel):
     """Esquema para atualização do plano de trabalho. Na atualização,
     todos os campos são opcionais, exceto cod_plano."""

--- a/schemas.py
+++ b/schemas.py
@@ -4,7 +4,7 @@ from datetime import date
 from enum import IntEnum
 
 class AtividadeSchema(BaseModel):
-    id_atividade: int = Field(title='id da atividade')
+    id_atividade: int = Field(title="id da atividade")
     nome_grupo_atividade: Optional[str]
     nome_atividade: str
     faixa_complexidade: str
@@ -27,17 +27,17 @@ class ModalidadeEnum(IntEnum):
     teletrabalho = 3
 
 class PlanoTrabalhoSchema(BaseModel):
-    cod_plano: str = Field(title='código do plano')
-    matricula_siape: int = Field(title='Matrícula SIAPE')
+    cod_plano: str = Field(title="código do plano")
+    matricula_siape: int = Field(title="Matrícula SIAPE")
     cpf: str = Field(
-        title='CPF',
-        description='Cadastro da pessoa física na Receita Federal do Brasil.\n'
-            '\n'
-            'Deve conter apenas dígitos.')
+        title="CPF",
+        description="Cadastro da pessoa física na Receita Federal do Brasil.\n"
+            "\n"
+            "Deve conter apenas dígitos.")
     nome_participante: str
     cod_unidade_exercicio: int
     nome_unidade_exercicio: str
-    modalidade_execucao: ModalidadeEnum = Field(..., alias='modalidade_execucao')
+    modalidade_execucao: ModalidadeEnum = Field(..., alias="modalidade_execucao")
     carga_horaria_semanal: int
     data_inicio: date
     data_fim: date
@@ -50,13 +50,13 @@ class PlanoTrabalhoSchema(BaseModel):
     # Validações
     @root_validator
     def data_validate(cls, values):
-        data_inicio = values.get('data_inicio', None)
-        data_fim = values.get('data_fim', None)
+        data_inicio = values.get("data_inicio", None)
+        data_fim = values.get("data_fim", None)
         if data_inicio > data_fim:
             raise ValueError("Data fim do Plano de Trabalho deve ser maior" \
                      " ou igual que Data início.")
-        for atividade in values.get('atividades', []):
-            if getattr(atividade, 'data_avaliacao', None) is not None and \
+        for atividade in values.get("atividades", []):
+            if getattr(atividade, "data_avaliacao", None) is not None and \
                 data_fim > atividade.data_avaliacao:
                     raise ValueError("Data de avaliação da atividade deve ser maior ou igual" \
                         " que a Data Fim do Plano de Trabalho.")
@@ -65,16 +65,16 @@ class PlanoTrabalhoSchema(BaseModel):
     @root_validator
     def validate_carga_horaria_total(cls, values):
         total_sum = 0
-        for a in values.get('atividades'):
-            total_sum += (getattr(a, 'tempo_exec_presencial') +
-                          getattr(a, 'tempo_exec_teletrabalho'))
-        if total_sum != values.get('carga_horaria_total'):
-            raise ValueError('A soma dos tempos de execução presencial e ' \
-                             'teletrabalho das atividades deve ser igual à ' \
-                             'carga_horaria_total.')
+        for a in values.get("atividades"):
+            total_sum += (getattr(a, "tempo_exec_presencial") +
+                          getattr(a, "tempo_exec_teletrabalho"))
+        if total_sum != values.get("carga_horaria_total"):
+            raise ValueError("A soma dos tempos de execução presencial e " \
+                             "teletrabalho das atividades deve ser igual à " \
+                             "carga_horaria_total.")
         return values
 
-    @validator('atividades')
+    @validator("atividades")
     def valida_atividades(cls, atividades):
         ids_atividades = [a.id_atividade for a in atividades]
         duplicados = []
@@ -86,42 +86,42 @@ class PlanoTrabalhoSchema(BaseModel):
         return atividades
 
 
-    @validator('cpf')
+    @validator("cpf")
     def cpf_validate(input_cpf):
         if not input_cpf.isdigit():
-            raise ValueError('CPF deve conter apenas digitos.')
+            raise ValueError("CPF deve conter apenas digitos.")
 
         cpf = [int(char) for char in input_cpf if char.isdigit()]
         #  Verifica se o CPF tem 11 dígitos
         if len(cpf) != 11:
-            raise ValueError('CPF precisa ter 11 digitos.')
+            raise ValueError("CPF precisa ter 11 digitos.")
 
         #  Verifica se o CPF tem todos os números iguais, ex: 111.111.111-11
         #  Esses CPFs são considerados inválidos mas passam na validação dos dígitos
         if len(set(cpf)) == 1:
-            raise ValueError('CPF inválido.')
+            raise ValueError("CPF inválido.")
 
         #  Valida os dois dígitos verificadores
         for i in range(9, 11):
             value = sum((cpf[num] * ((i+1) - num) for num in range(0, i)))
             digit = ((value * 10) % 11) % 10
             if digit != cpf[i]:
-                raise ValueError('Digitos verificadores do CPF inválidos.')
+                raise ValueError("Digitos verificadores do CPF inválidos.")
 
-        str_cpf = ''.join([str(i) for i in input_cpf])
+        str_cpf = "".join([str(i) for i in input_cpf])
         return str_cpf
 
-    @validator('carga_horaria_semanal')
+    @validator("carga_horaria_semanal")
     def must_be_less(cls, carga_horaria_semanal):
         if carga_horaria_semanal > 40 or carga_horaria_semanal <= 0:
-            raise ValueError('Carga horária semanal deve ser entre 1 e 40')
+            raise ValueError("Carga horária semanal deve ser entre 1 e 40")
         return carga_horaria_semanal
 
     class Config:
         orm_mode = True
 
 class AtividadeUpdateSchema(BaseModel):
-    id_atividade: int = Field(title='id da atividade')
+    id_atividade: int = Field(title="id da atividade")
     nome_grupo_atividade: Optional[str]
     nome_atividade: Optional[str]
     faixa_complexidade: Optional[str]
@@ -144,7 +144,7 @@ class PlanoTrabalhoUpdateSchema(BaseModel):
     nome_participante: Optional[str]
     cod_unidade_exercicio: Optional[int]
     nome_unidade_exercicio: Optional[str]
-    modalidade_execucao: ModalidadeEnum = Field(None, alias='modalidade_execucao')
+    modalidade_execucao: ModalidadeEnum = Field(None, alias="modalidade_execucao")
     carga_horaria_semanal: Optional[int]
     data_inicio: Optional[date]
     data_fim: Optional[date]

--- a/test_api.py
+++ b/test_api.py
@@ -14,6 +14,9 @@ from fastapi.testclient import TestClient
 from requests import Session
 from fastapi import status
 from api import app
+
+import util
+
 import pytest
 
 # Helper functions
@@ -172,6 +175,37 @@ fields_atividade = {
     )
 }
 
+atividades_dict = {
+    2: {
+        "nome_grupo_atividade": "string",
+        "nome_atividade": "string",
+        "faixa_complexidade": "string",
+        "parametros_complexidade": "string",
+        "tempo_exec_presencial": 0,
+        "tempo_exec_teletrabalho": 0,
+        "entrega_esperada": "string",
+        "qtde_entregas": 0,
+        "qtde_entregas_efetivas": 0,
+        "avaliacao": 0,
+        "data_avaliacao": "2021-01-15",
+    "justificativa": "string"
+    },
+    3: {
+        "nome_grupo_atividade": "string",
+        "nome_atividade": "string",
+        "faixa_complexidade": "string",
+        "parametros_complexidade": "string",
+        "tempo_exec_presencial": 0,
+        "tempo_exec_teletrabalho": 0,
+        "entrega_esperada": "string",
+        "qtde_entregas": 0,
+        "qtde_entregas_efetivas": 0,
+        "avaliacao": 0,
+        "data_avaliacao": "2021-01-15",
+        "justificativa": "string"
+    }
+}
+
 @pytest.fixture(scope="module")
 def admin_credentials() -> dict:
     return {
@@ -292,6 +326,8 @@ def header_usr_2(register_user_2, user2_credentials: dict) -> dict:
 
 
 # Tests
+
+# API Tests
 
 def test_register_user_not_logged_in(
         truncate_users, client: Session, header_not_logged_in: dict):
@@ -915,3 +951,30 @@ def test_create_pt_missing_mandatory_fields_atividade(input_pt: dict,
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = 'none is not an allowed value'
     assert response.json().get("detail")[0]["msg"] == detail_msg
+
+# Unit tests
+
+def test_merge_dicts(input_pt: dict):
+    """Testa a mesclagem de dicionários.
+    """
+    input1 = input_pt.copy()
+    input2 = input_pt.copy()
+
+    del input1['atividades'][0]['qtde_entregas']
+    del input2['atividades'][0]['avaliacao']
+
+    assert util.merge_dicts(input1, input2) == input_pt
+
+def test_list_to_dict(input_pt: dict):
+    """Testa a transformação de lista em dicionário.
+    """
+    atividades = util.list_to_dict(input_pt['atividades'], "id_atividade")
+
+    assert atividades == atividades_dict
+
+def test_dict_to_list(input_pt: dict):
+    """Testa a transformação de lista em dicionário.
+    """
+    atividades = util.dict_to_list(atividades_dict, "id_atividade")
+
+    assert atividades == input_pt['atividades']

--- a/test_api.py
+++ b/test_api.py
@@ -50,27 +50,27 @@ def prepare_header(username: Optional[str], password: Optional[str]) -> dict:
         url = "http://localhost:5057/auth/jwt/login"
 
         headers = {
-        'Content-Type': 'application/x-www-form-urlencoded'
+        "Content-Type": "application/x-www-form-urlencoded"
         }
 
-        payload='&'.join([
-            'accept=application%2Fjson',
-            'Content-Type=application%2Fjson',
-            f'username={username}',
-            f'password={password}'
+        payload="&".join([
+            "accept=application%2Fjson",
+            "Content-Type=application%2Fjson",
+            f"username={username}",
+            f"password={password}"
         ])
 
         response = requests.request("POST", url, headers=headers, data=payload)
         response_dict = json.loads(response.text)
-        token_user = response_dict.get('access_token')
+        token_user = response_dict.get("access_token")
         print(token_user)
 
     headers = {
-        'accept': 'application/json',
-        'Content-Type': 'application/json'
+        "accept": "application/json",
+        "Content-Type": "application/json"
     }
     if token_user:
-        headers['Authorization'] = f'Bearer {token_user}'
+        headers["Authorization"] = f"Bearer {token_user}"
     
     return headers
 
@@ -209,25 +209,25 @@ atividades_dict = {
 @pytest.fixture(scope="module")
 def admin_credentials() -> dict:
     return {
-        'username': 'admin@api.com',
-        'password': '1234',
-        'cod_unidade': 1
+        "username": "admin@api.com",
+        "password": "1234",
+        "cod_unidade": 1
     }
 
 @pytest.fixture(scope="module")
 def user1_credentials() -> dict:
     return {
-        'username': 'test1@api.com',
-        'password': 'api',
-        'cod_unidade': 1
+        "username": "test1@api.com",
+        "password": "api",
+        "cod_unidade": 1
     }
 
 @pytest.fixture(scope="module")
 def user2_credentials() -> dict:
     return {
-        'username': 'test2@api.com',
-        'password': 'api',
-        'cod_unidade': 2
+        "username": "test2@api.com",
+        "password": "api",
+        "cod_unidade": 2
     }
 
 @pytest.fixture()
@@ -244,9 +244,9 @@ def truncate_pt(client: Session, header_admin: dict):
 def truncate_users():
     p = subprocess.Popen(
         [
-            '/usr/local/bin/python',
-            '/home/api-pgd/admin_tool.py',
-            '--truncate-users'
+            "/usr/local/bin/python",
+            "/home/api-pgd/admin_tool.py",
+            "--truncate-users"
         ],
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -256,21 +256,21 @@ def truncate_users():
 
 @pytest.fixture(scope="module")
 def register_admin(truncate_users, admin_credentials: dict):
-    email = admin_credentials['username']
-    cod_unidade = admin_credentials['cod_unidade']
-    password = admin_credentials['password']
+    email = admin_credentials["username"]
+    cod_unidade = admin_credentials["cod_unidade"]
+    password = admin_credentials["password"]
     p = subprocess.Popen(
         [
-            '/usr/local/bin/python',
-            '/home/api-pgd/admin_tool.py',
-            '--create_superuser'
+            "/usr/local/bin/python",
+            "/home/api-pgd/admin_tool.py",
+            "--create_superuser"
         ],
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True
     )
-    p.communicate(input='\n'.join([
+    p.communicate(input="\n".join([
         email, str(cod_unidade), password, password
     ]))[0]
 
@@ -282,8 +282,8 @@ def register_user_1(
     header_admin: dict,
     user1_credentials: dict
     ) -> HTTPResponse:
-    return register_user(client, user1_credentials['username'],
-        user1_credentials['password'], user1_credentials['cod_unidade'],
+    return register_user(client, user1_credentials["username"],
+        user1_credentials["password"], user1_credentials["cod_unidade"],
         header_admin)
 
 @pytest.fixture(scope="module")
@@ -294,8 +294,8 @@ def register_user_2(
     header_admin: dict,
     user2_credentials: dict
     ) -> HTTPResponse:
-    return register_user(client, user2_credentials['username'],
-        user2_credentials['password'], user2_credentials['cod_unidade'],
+    return register_user(client, user2_credentials["username"],
+        user2_credentials["password"], user2_credentials["cod_unidade"],
         header_admin)
 
 @pytest.fixture(scope="module")
@@ -305,24 +305,24 @@ def header_not_logged_in() -> dict:
 @pytest.fixture(scope="module")
 def header_admin(register_admin, admin_credentials: dict) -> dict:
     return prepare_header(
-        username=admin_credentials['username'],
-        password=admin_credentials['password'])
+        username=admin_credentials["username"],
+        password=admin_credentials["password"])
 
 @pytest.fixture(scope="module")
 def header_usr_1(register_user_1, user1_credentials: dict) -> dict:
     """Authenticate in the API as user1 and return a dict with bearer
     header parameter to be passed to apis requests."""
     return prepare_header(
-        username=user1_credentials['username'],
-        password=user1_credentials['password'])
+        username=user1_credentials["username"],
+        password=user1_credentials["password"])
 
 @pytest.fixture(scope="module")
 def header_usr_2(register_user_2, user2_credentials: dict) -> dict:
     """Authenticate in the API as user2 and return a dict with bearer
     header parameter to be passed to apis requests."""
     return prepare_header(
-        username=user2_credentials['username'],
-        password=user2_credentials['password'])
+        username=user2_credentials["username"],
+        password=user2_credentials["password"])
 
 
 # Tests
@@ -349,24 +349,24 @@ def test_authenticate(header_usr_1: dict):
 
 def test_get_user_self_not_logged_in(client: Session,
         header_not_logged_in: dict):
-    response = client.get('/users/me', headers=header_not_logged_in)
+    response = client.get("/users/me", headers=header_not_logged_in)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 def test_get_user_self_logged_in(client: Session, user1_credentials: dict,
         header_usr_1: dict):
-    response = client.get('/users/me', headers=header_usr_1)
+    response = client.get("/users/me", headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data.get("email", None) == user1_credentials['username']
-    assert data.get("cod_unidade", None) == user1_credentials['cod_unidade']
+    assert data.get("email", None) == user1_credentials["username"]
+    assert data.get("cod_unidade", None) == user1_credentials["cod_unidade"]
     assert data.get("is_active", None) == True
 
 def test_patch_user_self_change_cod_unidade(client: Session,
         header_usr_1: dict):
     " Testa se o usuário pode alterar o seu próprio cod_unidade."
     response = client.patch(
-        '/users/me',
-        json={'cod_unidade': 3},
+        "/users/me",
+        json={"cod_unidade": 3},
         headers=header_usr_1
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -384,7 +384,7 @@ def test_create_plano_trabalho_completo(input_pt: dict,
     assert response.json() == input_pt
 
 @pytest.mark.parametrize("omitted_fields",
-                         enumerate(fields_plano_trabalho['optional']))
+                         enumerate(fields_plano_trabalho["optional"]))
 def test_create_plano_trabalho_omit_optional_fields(input_pt: dict,
                                              omitted_fields: list,
                                              header_usr_1: dict,
@@ -394,14 +394,14 @@ def test_create_plano_trabalho_omit_optional_fields(input_pt: dict,
     for field in field_list:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 557 + offset
+    input_pt["cod_plano"] = 557 + offset
     response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
 
 @pytest.mark.parametrize("missing_fields",
-                         enumerate(fields_plano_trabalho['mandatory']))
+                         enumerate(fields_plano_trabalho["mandatory"]))
 def test_create_plano_trabalho_missing_mandatory_fields(input_pt: dict,
                                              missing_fields: list,
                                              header_usr_1: dict,
@@ -417,7 +417,7 @@ def test_create_plano_trabalho_missing_mandatory_fields(input_pt: dict,
     for field in field_list:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 1800 + offset # precisa ser um novo plano
+    input_pt["cod_plano"] = 1800 + offset # precisa ser um novo plano
     response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -425,8 +425,8 @@ def test_create_plano_trabalho_missing_mandatory_fields(input_pt: dict,
 
 @pytest.mark.parametrize("verb, missing_fields",
                     itertools.product( # todas as combinações entre
-                        ('put', 'patch'), # verb
-                        fields_plano_trabalho['mandatory'] # missing_fields
+                        ("put", "patch"), # verb
+                        fields_plano_trabalho["mandatory"] # missing_fields
                     ))
 def test_update_plano_trabalho_missing_mandatory_fields(verb: str,
                                             example_pt,
@@ -447,18 +447,18 @@ def test_update_plano_trabalho_missing_mandatory_fields(verb: str,
     for field in missing_fields:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 555 # precisa ser um plano existente
+    input_pt["cod_plano"] = 555 # precisa ser um plano existente
     call = getattr(client, verb) # put ou patch
     response = call(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
-    if verb == 'put':
+    if verb == "put":
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    elif verb == 'patch':
+    elif verb == "patch":
         assert response.status_code == status.HTTP_200_OK
 
 @pytest.mark.parametrize("missing_fields",
-                            fields_plano_trabalho['mandatory'])
+                            fields_plano_trabalho["mandatory"])
 def test_patch_plano_trabalho_inexistente(truncate_pt,
                                             input_pt: dict,
                                             missing_fields: list,
@@ -473,14 +473,14 @@ def test_patch_plano_trabalho_inexistente(truncate_pt,
     for field in missing_fields:
         del input_pt[field]
 
-    input_pt['cod_plano'] = 999 # precisa ser um plano inexistente
+    input_pt["cod_plano"] = 999 # precisa ser um plano inexistente
     response = client.patch(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 @pytest.mark.parametrize("omitted_fields",
-                         enumerate(fields_atividade['optional']))
+                         enumerate(fields_atividade["optional"]))
 def test_create_atvidades_omit_optional_fields(input_pt: dict,
                                              omitted_fields: list,
                                              header_usr_1: dict,
@@ -491,10 +491,10 @@ def test_create_atvidades_omit_optional_fields(input_pt: dict,
     """
     offset, field_list = omitted_fields
     for field in field_list:
-        for atividade in input_pt['atividades']:
+        for atividade in input_pt["atividades"]:
             del atividade[field]
 
-    input_pt['cod_plano'] = 557 + offset
+    input_pt["cod_plano"] = 557 + offset
     response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -502,7 +502,7 @@ def test_create_atvidades_omit_optional_fields(input_pt: dict,
     assert response.status_code == status.HTTP_200_OK
 
 @pytest.mark.parametrize("missing_fields",
-                         enumerate(fields_atividade['mandatory']))
+                         enumerate(fields_atividade["mandatory"]))
 def test_create_atividades_missing_mandatory_fields(input_pt: dict,
                                              missing_fields: list,
                                              header_usr_1: dict,
@@ -513,10 +513,10 @@ def test_create_atividades_missing_mandatory_fields(input_pt: dict,
     """
     offset, field_list = missing_fields
     for field in field_list:
-        for atividade in input_pt['atividades']:
+        for atividade in input_pt["atividades"]:
             del atividade[field]
 
-    input_pt['cod_plano'] = 1800 + offset # precisa ser um novo plano
+    input_pt["cod_plano"] = 1800 + offset # precisa ser um novo plano
     response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -524,8 +524,8 @@ def test_create_atividades_missing_mandatory_fields(input_pt: dict,
 
 @pytest.mark.parametrize("verb, missing_fields",
                     itertools.product( # todas as combinações entre
-                        ('put', 'patch'), # verb
-                        fields_atividade['mandatory'] # missing_fields
+                        ("put", "patch"), # verb
+                        fields_atividade["mandatory"] # missing_fields
                     ))
 def test_update_atividades_missing_mandatory_fields(verb: str,
                                             truncate_pt,
@@ -545,17 +545,17 @@ def test_update_atividades_missing_mandatory_fields(verb: str,
     alteração. Por isso, é permitido omitir os campos obrigatórios.
     """
     for field in missing_fields:
-        for atividade in input_pt['atividades']:
+        for atividade in input_pt["atividades"]:
             del atividade[field]
 
-    input_pt['cod_plano'] = 555 # precisa ser um plano existente
+    input_pt["cod_plano"] = 555 # precisa ser um plano existente
     call = getattr(client, verb) # put ou patch
     response = call(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
-    if verb == 'put':
+    if verb == "put":
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    elif verb == 'patch':
+    elif verb == "patch":
         assert response.status_code == status.HTTP_200_OK
 
 def test_substitute_atividades_list(truncate_pt,
@@ -564,7 +564,7 @@ def test_substitute_atividades_list(truncate_pt,
                                     header_usr_1: dict,
                                     client: Session):
     "Substitui a lista de atividades existentes por uma nova lista."
-    input_pt['atividades'].pop() # remove a última atividade
+    input_pt["atividades"].pop() # remove a última atividade
 
     response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
                             json=input_pt,
@@ -626,7 +626,7 @@ def test_modify_atividade(truncate_pt,
                             header_usr_1: dict,
                             client: Session):
     "Modifica uma atividade existente com put e patch."
-    atividade = input_pt['atividades'][-1] # pega a última atividade
+    atividade = input_pt["atividades"][-1] # pega a última atividade
     atividade["data_avaliacao"] = data_avaliacao
 
     if verb == "put":
@@ -635,7 +635,7 @@ def test_modify_atividade(truncate_pt,
                           headers=header_usr_1)
     elif verb == "patch":
         atividade_patch = {
-            "cod_plano": input_pt['cod_plano'],
+            "cod_plano": input_pt["cod_plano"],
             "atividades": [
                 {
                     "id_atividade": 3,
@@ -648,7 +648,7 @@ def test_modify_atividade(truncate_pt,
                           headers=header_usr_1)
     
     if datetime.fromisoformat(data_avaliacao) < datetime.fromisoformat(
-                                                    input_pt['data_fim']):
+                                                    input_pt["data_fim"]):
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         detail_msg = "Data de avaliação da atividade deve ser maior ou igual" \
                      " que a Data Fim do Plano de Trabalho."
@@ -686,9 +686,9 @@ def test_get_pt_inexistente(header_usr_1: dict, client: Session):
 
 @pytest.mark.parametrize("data_inicio, data_fim, cod_plano, id_ati_1, id_ati_2",
                           [
-                            ("2020-06-04", "2020-04-01", '77', 333, 334),
-                            ("2020-06-04", "2020-04-01", '78', 335, 336),
-                            ("2020-06-04", "2020-04-01", '79', 337, 338),
+                            ("2020-06-04", "2020-04-01", "77", 333, 334),
+                            ("2020-06-04", "2020-04-01", "78", 335, 336),
+                            ("2020-06-04", "2020-04-01", "79", 337, 338),
                             ])
 def test_create_pt_invalid_dates(input_pt: dict,
                                  data_inicio: str,
@@ -699,11 +699,11 @@ def test_create_pt_invalid_dates(input_pt: dict,
                                  header_usr_1: dict,
                                  truncate_pt,
                                  client: Session):
-    input_pt['data_inicio'] = data_inicio
-    input_pt['data_fim'] = data_fim
-    input_pt['cod_plano'] = cod_plano
-    input_pt['atividades'][0]['id_atividade'] = id_ati_1
-    input_pt['atividades'][1]['id_atividade'] = id_ati_2
+    input_pt["data_inicio"] = data_inicio
+    input_pt["data_fim"] = data_fim
+    input_pt["cod_plano"] = cod_plano
+    input_pt["atividades"][0]["id_atividade"] = id_ati_1
+    input_pt["atividades"][1]["id_atividade"] = id_ati_2
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
@@ -719,12 +719,12 @@ def test_create_pt_invalid_dates(input_pt: dict,
 @pytest.mark.parametrize(
     "dt_fim, dt_avaliacao_1, dt_avaliacao_2, cod_plano, id_ati_1, id_ati_2",
     [
-      ("2020-06-04", "2020-04-01", "2020-04-01", '77', 333, 334),
-      ("2020-06-04", "2020-04-01", "2021-04-01", '78', 335, 336),
-      ("2020-06-04", "2020-04-01", "2019-04-01", '79', 337, 338),
-      ("2020-04-01", "2020-04-01", "2020-06-04", '80', 339, 340),
-      ("2020-04-01", "2020-04-01", "2020-04-01", '81', 341, 342),
-      ("2020-04-01", "2020-02-01", "2020-01-04", '82', 343, 344),
+      ("2020-06-04", "2020-04-01", "2020-04-01", "77", 333, 334),
+      ("2020-06-04", "2020-04-01", "2021-04-01", "78", 335, 336),
+      ("2020-06-04", "2020-04-01", "2019-04-01", "79", 337, 338),
+      ("2020-04-01", "2020-04-01", "2020-06-04", "80", 339, 340),
+      ("2020-04-01", "2020-04-01", "2020-04-01", "81", 341, 342),
+      ("2020-04-01", "2020-02-01", "2020-01-04", "82", 343, 344),
       ])
 def test_create_pt_invalid_data_avaliacao(input_pt: dict,
                                           dt_fim: str,
@@ -736,13 +736,13 @@ def test_create_pt_invalid_data_avaliacao(input_pt: dict,
                                           header_usr_1: dict,
                                           truncate_pt,
                                           client: Session):
-    input_pt['data_inicio'] = "2020-01-01"
-    input_pt['data_fim'] = dt_fim
-    input_pt['cod_plano'] = cod_plano
-    input_pt['atividades'][0]['id_atividade'] = id_ati_1
-    input_pt['atividades'][0]['data_avaliacao'] = dt_avaliacao_1
-    input_pt['atividades'][1]['id_atividade'] = id_ati_2
-    input_pt['atividades'][1]['data_avaliacao'] = dt_avaliacao_2
+    input_pt["data_inicio"] = "2020-01-01"
+    input_pt["data_fim"] = dt_fim
+    input_pt["cod_plano"] = cod_plano
+    input_pt["atividades"][0]["id_atividade"] = id_ati_1
+    input_pt["atividades"][0]["data_avaliacao"] = dt_avaliacao_1
+    input_pt["atividades"][1]["id_atividade"] = id_ati_2
+    input_pt["atividades"][1]["data_avaliacao"] = dt_avaliacao_2
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
@@ -757,10 +757,10 @@ def test_create_pt_invalid_data_avaliacao(input_pt: dict,
 
 @pytest.mark.parametrize("cod_plano, id_ati_1, id_ati_2",
                           [
-                            ('90', 401, 402),
-                            ('91', 403, 403), # <<<< IGUAIS
-                            ('92', 404, 404), # <<<< IGUAIS
-                            ('93', 405, 406),
+                            ("90", 401, 402),
+                            ("91", 403, 403), # <<<< IGUAIS
+                            ("92", 404, 404), # <<<< IGUAIS
+                            ("93", 405, 406),
                             ])
 def test_create_pt_duplicate_atividade(input_pt: dict,
                                        cod_plano: str,
@@ -769,9 +769,9 @@ def test_create_pt_duplicate_atividade(input_pt: dict,
                                        header_usr_1: dict,
                                        truncate_pt,
                                        client: Session):
-    input_pt['cod_plano'] = cod_plano
-    input_pt['atividades'][0]['id_atividade'] = id_ati_1
-    input_pt['atividades'][1]['id_atividade'] = id_ati_2
+    input_pt["cod_plano"] = cod_plano
+    input_pt["atividades"][0]["id_atividade"] = id_ati_1
+    input_pt["atividades"][1]["id_atividade"] = id_ati_2
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
@@ -799,20 +799,20 @@ def test_update_pt_different_cod_unidade(truncate_pt,
 
 @pytest.mark.parametrize("cod_plano, cpf",
                           [
-                            ('100', '11111111111'),
-                            ('101', '22222222222'),
-                            ('102', '33333333333'),
-                            ('103', '44444444444'),
-                            ('104', '04811556435'),
-                            ('103', '444-444-444.44'),
-                            ('108', '-44444444444'),
-                            ('111', '444444444'),
-                            ('112', '-444 4444444'),
-                            ('112', '4811556437'),
-                            ('112', '048115564-37'),
-                            ('112', '04811556437     '),
-                            ('112', '    04811556437     '),
-                            ('112', ''),
+                            ("100", "11111111111"),
+                            ("101", "22222222222"),
+                            ("102", "33333333333"),
+                            ("103", "44444444444"),
+                            ("104", "04811556435"),
+                            ("103", "444-444-444.44"),
+                            ("108", "-44444444444"),
+                            ("111", "444444444"),
+                            ("112", "-444 4444444"),
+                            ("112", "4811556437"),
+                            ("112", "048115564-37"),
+                            ("112", "04811556437     "),
+                            ("112", "    04811556437     "),
+                            ("112", ""),
                             ])
 def test_create_pt_invalid_cpf(input_pt: dict,
                                cod_plano: str,
@@ -820,27 +820,27 @@ def test_create_pt_invalid_cpf(input_pt: dict,
                                header_usr_1: dict,
                                truncate_pt,
                                client: Session):
-    input_pt['cod_plano'] = cod_plano
-    input_pt['cpf'] = cpf
+    input_pt["cod_plano"] = cod_plano
+    input_pt["cpf"] = cpf
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = [
-        'Digitos verificadores do CPF inválidos.',
-        'CPF inválido.',
-        'CPF precisa ter 11 digitos.',
-        'CPF deve conter apenas digitos.',
+        "Digitos verificadores do CPF inválidos.",
+        "CPF inválido.",
+        "CPF precisa ter 11 digitos.",
+        "CPF deve conter apenas digitos.",
     ]
     assert response.json().get("detail")[0]["msg"] in detail_msg
 
 
 @pytest.mark.parametrize("cod_plano, modalidade_execucao",
                           [
-                            ('556', -1),
-                            ('81', -2),
-                            ('82', -3)
+                            ("556", -1),
+                            ("81", -2),
+                            ("82", -3)
                             ])
 def test_create_pt_invalid_modalidade_execucao(input_pt: dict,
                                cod_plano: str,
@@ -848,8 +848,8 @@ def test_create_pt_invalid_modalidade_execucao(input_pt: dict,
                                header_usr_1: dict,
                                truncate_pt,
                                client: Session):
-    input_pt['cod_plano'] = cod_plano
-    input_pt['modalidade_execucao'] = modalidade_execucao
+    input_pt["cod_plano"] = cod_plano
+    input_pt["modalidade_execucao"] = modalidade_execucao
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -869,9 +869,9 @@ def test_create_pt_invalid_carga_horaria_semanal(input_pt: dict,
                                                  header_usr_1: dict,
                                                  truncate_pt,
                                                  client: Session):
-    cod_plano = '767676'
-    input_pt['cod_plano'] = cod_plano
-    input_pt['carga_horaria_semanal'] = carga_horaria_semanal
+    cod_plano = "767676"
+    input_pt["cod_plano"] = cod_plano
+    input_pt["carga_horaria_semanal"] = carga_horaria_semanal
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -896,33 +896,33 @@ def test_create_pt_invalid_carga_horaria_total(input_pt: dict,
                                                  truncate_pt,
                                                  client: Session):
     cod_plano = 767677
-    input_pt['cod_plano'] = cod_plano
-    input_pt['carga_horaria_total'] = carga_horaria_total
-    input_pt['atividades'][0]['tempo_exec_presencial'] = tempo_pres_1
-    input_pt['atividades'][0]['tempo_exec_teletrabalho'] = tempo_tel_1
-    input_pt['atividades'][1]['tempo_exec_presencial'] = tempo_pres_2
-    input_pt['atividades'][1]['tempo_exec_teletrabalho'] = tempo_tel_2
+    input_pt["cod_plano"] = cod_plano
+    input_pt["carga_horaria_total"] = carga_horaria_total
+    input_pt["atividades"][0]["tempo_exec_presencial"] = tempo_pres_1
+    input_pt["atividades"][0]["tempo_exec_teletrabalho"] = tempo_tel_1
+    input_pt["atividades"][1]["tempo_exec_presencial"] = tempo_pres_2
+    input_pt["atividades"][1]["tempo_exec_teletrabalho"] = tempo_tel_2
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_msg = 'A soma dos tempos de execução presencial e ' \
-                 'teletrabalho das atividades deve ser igual à ' \
-                 'carga_horaria_total.'
+    detail_msg = "A soma dos tempos de execução presencial e " \
+                 "teletrabalho das atividades deve ser igual à " \
+                 "carga_horaria_total."
     assert response.json().get("detail")[0]["msg"] == detail_msg
 
 @pytest.mark.parametrize(
     "id_atividade, nome_atividade, faixa_complexidade, "\
     "tempo_exec_presencial, tempo_exec_teletrabalho, qtde_entregas",
                           [
-                              (None, 'asd', 'asd', 0, 0, 3),
-                              (123123, None, 'asd', 0, 0, 3),
-                              (123123, 'asd', None, 0, 0, 3),
-                              (123123, 'asd', 'asd', None, 0, 3),
-                              (123123, 'asd', 'asd', 0, None, 3),
-                              (123123, 'asd', 'asd', 0, 0, None),
+                              (None, "asd", "asd", 0, 0, 3),
+                              (123123, None, "asd", 0, 0, 3),
+                              (123123, "asd", None, 0, 0, 3),
+                              (123123, "asd", "asd", None, 0, 3),
+                              (123123, "asd", "asd", 0, None, 3),
+                              (123123, "asd", "asd", 0, 0, None),
                            ])
 def test_create_pt_missing_mandatory_fields_atividade(input_pt: dict,
 
@@ -936,20 +936,20 @@ def test_create_pt_missing_mandatory_fields_atividade(input_pt: dict,
                                            header_usr_1: dict,
                                            truncate_pt,
                                            client: Session):
-    cod_plano = '111222333'
-    input_pt['cod_plano'] = cod_plano
-    input_pt['atividades'][0]['id_atividade'] = id_atividade
-    input_pt['atividades'][0]['nome_atividade'] = nome_atividade
-    input_pt['atividades'][0]['faixa_complexidade'] = faixa_complexidade
-    input_pt['atividades'][0]['tempo_exec_presencial'] = tempo_exec_presencial
-    input_pt['atividades'][0]['tempo_exec_teletrabalho'] = tempo_exec_teletrabalho
-    input_pt['atividades'][0]['qtde_entregas'] = qtde_entregas
+    cod_plano = "111222333"
+    input_pt["cod_plano"] = cod_plano
+    input_pt["atividades"][0]["id_atividade"] = id_atividade
+    input_pt["atividades"][0]["nome_atividade"] = nome_atividade
+    input_pt["atividades"][0]["faixa_complexidade"] = faixa_complexidade
+    input_pt["atividades"][0]["tempo_exec_presencial"] = tempo_exec_presencial
+    input_pt["atividades"][0]["tempo_exec_teletrabalho"] = tempo_exec_teletrabalho
+    input_pt["atividades"][0]["qtde_entregas"] = qtde_entregas
 
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_msg = 'none is not an allowed value'
+    detail_msg = "none is not an allowed value"
     assert response.json().get("detail")[0]["msg"] == detail_msg
 
 # Unit tests
@@ -960,15 +960,15 @@ def test_merge_dicts(input_pt: dict):
     input1 = input_pt.copy()
     input2 = input_pt.copy()
 
-    del input1['atividades'][0]['qtde_entregas']
-    del input2['atividades'][0]['avaliacao']
+    del input1["atividades"][0]["qtde_entregas"]
+    del input2["atividades"][0]["avaliacao"]
 
     assert util.merge_dicts(input1, input2) == input_pt
 
 def test_list_to_dict(input_pt: dict):
     """Testa a transformação de lista em dicionário.
     """
-    atividades = util.list_to_dict(input_pt['atividades'], "id_atividade")
+    atividades = util.list_to_dict(input_pt["atividades"], "id_atividade")
 
     assert atividades == atividades_dict
 
@@ -977,4 +977,4 @@ def test_dict_to_list(input_pt: dict):
     """
     atividades = util.dict_to_list(atividades_dict, "id_atividade")
 
-    assert atividades == input_pt['atividades']
+    assert atividades == input_pt["atividades"]

--- a/test_api.py
+++ b/test_api.py
@@ -592,6 +592,39 @@ def test_append_atividades_list(truncate_pt,
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == input_pt
 
+@pytest.mark.parametrize("verb",
+                            ("put", "patch")
+                        )
+def test_modify_atividade(truncate_pt,
+                            example_pt,
+                            verb: str,
+                            input_pt: dict,
+                            header_usr_1: dict,
+                            client: Session):
+    "Modifica uma atividade existente com put e patch."
+    atividade = input_pt['atividades'][-1] # pega a última atividade
+    atividade["data_avaliacao"] = "2021-03-01"
+
+    if verb == "put":
+        response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
+                          json=input_pt,
+                          headers=header_usr_1)
+    elif verb == "patch":
+        atividade_patch = {
+            "atividades": [
+                {
+                    "id_atividade": 3,
+                    "data_avaliacao": "2021-03-01"
+                }
+            ]
+        }
+        response = client.patch(f"/plano_trabalho/{input_pt['cod_plano']}",
+                          json=atividade_patch,
+                          headers=header_usr_1)
+    
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == input_pt
+
 def test_create_pt_cod_plano_inconsistent(input_pt: dict,
                                           header_usr_1: dict,
                                           truncate_pt,

--- a/test_api.py
+++ b/test_api.py
@@ -512,6 +512,7 @@ def test_create_atividades_missing_mandatory_fields(input_pt: dict,
                         fields_atividade['mandatory'] # missing_fields
                     ))
 def test_update_atividades_missing_mandatory_fields(verb: str,
+                                            truncate_pt,
                                             example_pt,
                                             input_pt: dict,
                                             missing_fields: list,
@@ -540,6 +541,56 @@ def test_update_atividades_missing_mandatory_fields(verb: str,
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     elif verb == 'patch':
         assert response.status_code == status.HTTP_200_OK
+
+def test_substitute_atividades_list(truncate_pt,
+                                    example_pt,
+                                    input_pt: dict,
+                                    header_usr_1: dict,
+                                    client: Session):
+    "Substitui a lista de atividades existentes por uma nova lista."
+    input_pt['atividades'].pop() # remove a última atividade
+
+    response = client.put(f"/plano_trabalho/{input_pt['cod_plano']}",
+                            json=input_pt,
+                            headers=header_usr_1)
+    
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == input_pt
+
+def test_append_atividades_list(truncate_pt,
+                                example_pt,
+                                input_pt: dict,
+                                header_usr_1: dict,
+                                client: Session):
+    "Acrescenta uma nova atividade à lista de atividades existentes."
+    nova_atividade = {
+      "id_atividade": 4,
+      "nome_grupo_atividade": "string",
+      "nome_atividade": "string",
+      "faixa_complexidade": "string",
+      "parametros_complexidade": "string",
+      "tempo_exec_presencial": 0,
+      "tempo_exec_teletrabalho": 0,
+      "entrega_esperada": "string",
+      "qtde_entregas": 0,
+      "qtde_entregas_efetivas": 0,
+      "avaliacao": 0,
+      "data_avaliacao": "2021-02-15",
+      "justificativa": "string"
+    }
+
+    patch_input = {
+        "atividades": [nova_atividade]
+    }
+
+    response = client.patch(f"/plano_trabalho/{input_pt['cod_plano']}",
+                            json=patch_input,
+                            headers=header_usr_1)
+    
+    input_pt["atividades"].append(nova_atividade)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == input_pt
 
 def test_create_pt_cod_plano_inconsistent(input_pt: dict,
                                           header_usr_1: dict,

--- a/test_api.py
+++ b/test_api.py
@@ -82,54 +82,95 @@ def client() -> Generator[Session, None, None]:
 @pytest.fixture()
 def input_pt() -> dict:
     pt_json = {
-  "cod_plano": "555",
-  "matricula_siape": 0,
-  "cpf": "99160773120",
-  "nome_participante": "string",
-  "cod_unidade_exercicio": 0,
-  "nome_unidade_exercicio": "string",
-  "modalidade_execucao": 1,
-  "carga_horaria_semanal": 10,
-  "data_inicio": "2021-01-07",
-  "data_fim": "2021-01-12",
-  "carga_horaria_total": 0,
-  "data_interrupcao": "2021-01-07",
-  "entregue_no_prazo": True,
-  "horas_homologadas": 0,
-  "atividades": [
-    {
-      "id_atividade": 2,
-      "nome_grupo_atividade": "string",
-      "nome_atividade": "string",
-      "faixa_complexidade": "string",
-      "parametros_complexidade": "string",
-      "tempo_exec_presencial": 0,
-      "tempo_exec_teletrabalho": 0,
-      "entrega_esperada": "string",
-      "qtde_entregas": 0,
-      "qtde_entregas_efetivas": 0,
-      "avaliacao": 0,
-      "data_avaliacao": "2021-01-15",
-      "justificativa": "string"
-    },
-    {
-      "id_atividade": 3,
-      "nome_grupo_atividade": "string",
-      "nome_atividade": "string",
-      "faixa_complexidade": "string",
-      "parametros_complexidade": "string",
-      "tempo_exec_presencial": 0,
-      "tempo_exec_teletrabalho": 0,
-      "entrega_esperada": "string",
-      "qtde_entregas": 0,
-      "qtde_entregas_efetivas": 0,
-      "avaliacao": 0,
-      "data_avaliacao": "2021-01-15",
-      "justificativa": "string"
+        "cod_plano": "555",
+        "matricula_siape": 0,
+        "cpf": "99160773120",
+        "nome_participante": "string",
+        "cod_unidade_exercicio": 0,
+        "nome_unidade_exercicio": "string",
+        "modalidade_execucao": 1,
+        "carga_horaria_semanal": 10,
+        "data_inicio": "2021-01-07",
+        "data_fim": "2021-01-12",
+        "carga_horaria_total": 0,
+        "data_interrupcao": "2021-01-07",
+        "entregue_no_prazo": True,
+        "horas_homologadas": 0,
+        "atividades": [
+            {
+                "id_atividade": 2,
+                "nome_grupo_atividade": "string",
+                "nome_atividade": "string",
+                "faixa_complexidade": "string",
+                "parametros_complexidade": "string",
+                "tempo_exec_presencial": 0,
+                "tempo_exec_teletrabalho": 0,
+                "entrega_esperada": "string",
+                "qtde_entregas": 0,
+                "qtde_entregas_efetivas": 0,
+                "avaliacao": 0,
+                "data_avaliacao": "2021-01-15",
+                "justificativa": "string"
+            },
+            {
+                "id_atividade": 3,
+                "nome_grupo_atividade": "string",
+                "nome_atividade": "string",
+                "faixa_complexidade": "string",
+                "parametros_complexidade": "string",
+                "tempo_exec_presencial": 0,
+                "tempo_exec_teletrabalho": 0,
+                "entrega_esperada": "string",
+                "qtde_entregas": 0,
+                "qtde_entregas_efetivas": 0,
+                "avaliacao": 0,
+                "data_avaliacao": "2021-01-15",
+                "justificativa": "string"
+            }
+        ]
     }
-  ]
-}
     return pt_json
+
+# grupos de campos opcionais e obrigatórios a testar
+
+fields_plano_trabalho = {
+    "optional": (
+        ["data_interrupcao"],
+        ["data_interrupcao", "entregue_no_prazo"],
+        ["entregue_no_prazo"],
+    ),
+    "mandatory": (
+        ["matricula_siape"],
+        ["cpf"],
+        ["nome_participante"],
+        ["cod_unidade_exercicio"],
+        ["nome_unidade_exercicio"],
+        ["modalidade_execucao"],
+        ["carga_horaria_semanal"],
+        ["data_inicio"],
+        ["data_fim"],
+        ["carga_horaria_total"],
+        ["atividades"],
+    )
+}
+
+fields_atividade = {
+    "optional": (
+        ["nome_grupo_atividade"],
+        ["parametros_complexidade"],
+        ["entrega_esperada"],
+        ["qtde_entregas_efetivas"],
+        ["data_avaliacao"],
+        ["justificativa"],
+    ),
+    "mandatory": (
+        ["nome_atividade"],
+        ["faixa_complexidade"],
+        ["tempo_exec_presencial"],
+        ["tempo_exec_teletrabalho"],
+        ["qtde_entregas"],
+    )
+}
 
 @pytest.fixture(scope="module")
 def admin_credentials() -> dict:
@@ -305,47 +346,6 @@ def test_create_plano_trabalho_completo(input_pt: dict,
     assert response.status_code == status.HTTP_200_OK
     assert response.json().get("detail", None) == None
     assert response.json() == input_pt
-
-# grupos de campos opcionais e obrigatórios a testar
-
-fields_plano_trabalho = {
-    "optional": (
-        ["data_interrupcao"],
-        ["data_interrupcao", "entregue_no_prazo"],
-        ["entregue_no_prazo"],
-    ),
-    "mandatory": (
-        ["matricula_siape"],
-        ["cpf"],
-        ["nome_participante"],
-        ["cod_unidade_exercicio"],
-        ["nome_unidade_exercicio"],
-        ["modalidade_execucao"],
-        ["carga_horaria_semanal"],
-        ["data_inicio"],
-        ["data_fim"],
-        ["carga_horaria_total"],
-        ["atividades"],
-    )
-}
-
-fields_atividade = {
-    "optional": (
-        ["nome_grupo_atividade"],
-        ["parametros_complexidade"],
-        ["entrega_esperada"],
-        ["qtde_entregas_efetivas"],
-        ["data_avaliacao"],
-        ["justificativa"],
-    ),
-    "mandatory": (
-        ["nome_atividade"],
-        ["faixa_complexidade"],
-        ["tempo_exec_presencial"],
-        ["tempo_exec_teletrabalho"],
-        ["qtde_entregas"],
-    )
-}
 
 @pytest.mark.parametrize("omitted_fields",
                          enumerate(fields_plano_trabalho['optional']))

--- a/test_api.py
+++ b/test_api.py
@@ -433,7 +433,7 @@ def test_update_plano_trabalho_missing_mandatory_fields(verb: str,
         del input_pt[field]
 
     input_pt['cod_plano'] = 555 # precisa ser um plano existente
-    call = getattr(client, verb)
+    call = getattr(client, verb) # put ou patch
     response = call(f"/plano_trabalho/{input_pt['cod_plano']}",
                           json=input_pt,
                           headers=header_usr_1)
@@ -487,7 +487,7 @@ def test_create_atvidades_omit_optional_fields(input_pt: dict,
 
 @pytest.mark.parametrize("missing_fields",
                          enumerate(fields_atividade['mandatory']))
-def test_create_atividade_missing_mandatory_fields(input_pt: dict,
+def test_create_atividades_missing_mandatory_fields(input_pt: dict,
                                              missing_fields: list,
                                              header_usr_1: dict,
                                              truncate_pt,
@@ -505,6 +505,41 @@ def test_create_atividade_missing_mandatory_fields(input_pt: dict,
                           json=input_pt,
                           headers=header_usr_1)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+@pytest.mark.parametrize("verb, missing_fields",
+                    itertools.product( # todas as combinações entre
+                        ('put', 'patch'), # verb
+                        fields_atividade['mandatory'] # missing_fields
+                    ))
+def test_update_atividades_missing_mandatory_fields(verb: str,
+                                            example_pt,
+                                            input_pt: dict,
+                                            missing_fields: list,
+                                            header_usr_1: dict,
+                                            client: Session):
+    """Tenta atualizar as atividades de um plano de trabalho faltando
+    campos obrigatórios.
+
+    Para usar o verbo PUT é necessário passar a representação completa
+    do recurso. Por isso, os campos obrigatórios não podem estar
+    faltando. Para realizar uma atualização parcial, use o método PATCH.
+
+    Já com o verbo PATCH, os campos omitidos são interpretados como sem
+    alteração. Por isso, é permitido omitir os campos obrigatórios.
+    """
+    for field in missing_fields:
+        for atividade in input_pt['atividades']:
+            del atividade[field]
+
+    input_pt['cod_plano'] = 555 # precisa ser um plano existente
+    call = getattr(client, verb) # put ou patch
+    response = call(f"/plano_trabalho/{input_pt['cod_plano']}",
+                          json=input_pt,
+                          headers=header_usr_1)
+    if verb == 'put':
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    elif verb == 'patch':
+        assert response.status_code == status.HTTP_200_OK
 
 def test_create_pt_cod_plano_inconsistent(input_pt: dict,
                                           header_usr_1: dict,

--- a/test_api.py
+++ b/test_api.py
@@ -583,6 +583,7 @@ def test_append_atividades_list(truncate_pt,
     }
 
     patch_input = {
+        "cod_plano": input_pt["cod_plano"],
         "atividades": [nova_atividade]
     }
 

--- a/test_api.py
+++ b/test_api.py
@@ -37,6 +37,9 @@ def register_user(
     )
 
 def prepare_header(username: Optional[str], password: Optional[str]) -> dict:
+    """Prepara o cabeçalho para ser utilizado em requisições.
+    """
+    #TODO: Refatorar e resolver utilizando o objeto TestClient
     token_user = None
 
     if username and password:
@@ -234,26 +237,6 @@ def header_admin(register_admin, admin_credentials: dict) -> dict:
 def header_usr_1(register_user_1, user1_credentials: dict) -> dict:
     """Authenticate in the API as user1 and return a dict with bearer
     header parameter to be passed to apis requests."""
-    #TODO: Refatorar e resolver utilizando o objeto TestClient
-    # data = {
-    #     'grant_type': '',
-    #     'username': 'nitai@example.com',
-    #     'password': 'string',
-    #     'scope': '',
-    #     'client_id': '',
-    #     'client_secret': ''
-    # }
-    # response = client.post(f"/auth/jwt/login", data=data)
-    # print(response)
-    # return response.json().get("access_token")
-
-    # shell_cmd = 'curl -X POST "http://192.168.0.206:5057/auth/jwt/login"' \
-    #                 ' -H  "accept: application/json"' \
-    #                 ' -H  "Content-Type: application/json"' \
-    #                 ' -d "grant_type=&username=test1%40api.com&password=api&scope=&client_id=&client_secret="'
-    # my_cmd = os.popen(shell_cmd).read()
-    # response = json.loads(my_cmd)
-    # token_user_1 = response.get('access_token')
     return prepare_header(
         username=user1_credentials['username'],
         password=user1_credentials['password'])
@@ -265,12 +248,6 @@ def header_usr_2(register_user_2, user2_credentials: dict) -> dict:
     return prepare_header(
         username=user2_credentials['username'],
         password=user2_credentials['password'])
-
-# @pytest.fixture(scope="module")
-# def insert_pt_user_1(header_usr_1, client):
-#     client.put(f"/plano_trabalho/888888888",
-#                json=input_pt,
-#                headers=header_usr_1)
 
 
 # Tests

--- a/test_api.py
+++ b/test_api.py
@@ -813,7 +813,7 @@ def test_create_pt_invalid_cpf(input_pt: dict,
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = [
         'Digitos verificadores do CPF inválidos.',
         'CPF inválido.',
@@ -841,7 +841,7 @@ def test_create_pt_invalid_modalidade_execucao(input_pt: dict,
                           json=input_pt,
                           headers=header_usr_1)
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = "value is not a valid enumeration member; permitted: 1, 2, 3"
     assert response.json().get("detail")[0]["msg"] == detail_msg
 
@@ -863,7 +863,7 @@ def test_create_pt_invalid_carga_horaria_semanal(input_pt: dict,
                           json=input_pt,
                           headers=header_usr_1)
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = "Carga horária semanal deve ser entre 1 e 40"
     assert response.json().get("detail")[0]["msg"] == detail_msg
 
@@ -894,7 +894,7 @@ def test_create_pt_invalid_carga_horaria_total(input_pt: dict,
                           json=input_pt,
                           headers=header_usr_1)
 
-    assert response.status_code == 422
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = 'A soma dos tempos de execução presencial e ' \
                  'teletrabalho das atividades deve ser igual à ' \
                  'carga_horaria_total.'
@@ -935,7 +935,6 @@ def test_create_pt_missing_mandatory_fields_atividade(input_pt: dict,
     response = client.put(f"/plano_trabalho/{cod_plano}",
                           json=input_pt,
                           headers=header_usr_1)
-    assert response.status_code == 422
-    #TODO: Melhorar resposta automática do Pydantic para deixar claro qual campo não passou na validação
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     detail_msg = 'none is not an allowed value'
     assert response.json().get("detail")[0]["msg"] == detail_msg

--- a/util.py
+++ b/util.py
@@ -10,7 +10,7 @@ def sa_obj_to_dict(d: dict) -> dict:
                 for item in v
             ] if isinstance(v, list) and v else v
         for k, v in d.__dict__.items()
-        if not k.startswith('_')
+        if not k.startswith("_")
     }
 
 def merge_dicts(d1: dict, d2:dict) -> dict:

--- a/util.py
+++ b/util.py
@@ -1,0 +1,56 @@
+"""Funções de utilidade comum.
+"""
+
+def sa_obj_to_dict(d: dict) -> dict:
+    "Copia os valores do objeto SQL Alchemy para um dicionário."
+    return {
+        k:
+            [
+                sa_obj_to_dict(item)
+                for item in v
+            ] if isinstance(v, list) and v else v
+        for k, v in d.__dict__.items()
+        if not k.startswith('_')
+    }
+
+def merge_dicts(d1: dict, d2:dict) -> dict:
+    "Atualiza d1 com os valores de d2."
+    # os que estão em d1, atualizar com d2
+    d = {
+        k: merge_dicts(v, d2.get(k, {})) \
+            if isinstance(v, dict) and v \
+            else d2.get(k, v)
+        for k, v in d1.items()
+    }
+    # os que estão em d2 mas não em d1, copiar de d2
+    d.update({
+        k: v
+        for k, v in d2.items()
+        if k not in d1.keys()
+    })
+    return d
+
+def list_to_dict(l: list, id_attr: str) -> dict:
+    "Transforma uma lista em dicionário, tomando o id como chave."
+    return {
+        entry.get(id_attr): {
+            key: value
+            for key, value in entry.items() if key != id_attr
+        }
+        for entry in l
+    }
+
+def dict_to_list(d: dict, id_attr: str) -> list:
+    "Transforma um dicionário em lista, tomando o id como chave."
+    return [
+        merge_dicts(
+            {
+                id_attr: item_id
+            },
+            {
+                key: value
+                for key, value in prop.items()
+            }
+        )
+        for item_id, prop in d.items()
+    ]

--- a/util.py
+++ b/util.py
@@ -52,5 +52,5 @@ def dict_to_list(d: dict, id_attr: str) -> list:
                 for key, value in prop.items()
             }
         )
-        for item_id, prop in d.items()
+        for item_id, prop in sorted(d.items())
     ]


### PR DESCRIPTION
Implementa #1 e #5. Ainda falta implementar que os campos obrigatórios funcionem como obrigatórios e os opcionais funcionem como opcionais para as atividades dentro do plano de trabalho.

Atentar para a diferença de funcionamento entre PUT e PATCH. O primeiro cria ou substitui. O último altera os campos informados e ignora os campos não informados.

Testes:

* [x] omitir campos obrigatórios e opcionais ao criar (PUT)
* [x] omitir campos obrigatórios ao substituir (PUT) deve falhar
* [x] omitir campos obrigatórios ao alterar (PATCH) deve aceitar
* [x] substituir a lista de atividades (PUT)
* [x] acrescentar nova atividade (PATCH)
* [x] modificar o conteúdo de uma atividade (PUT e PATCH)

Implementação:
* [x] passar todos os testes