### PR TITLE
Resolve a race condition entre containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - POSTGRES_DB=api_pgd
   web:
     image: api-pgd:latest
-    command: uvicorn api:app --host 0.0.0.0 --port 5057 --reload
+    command:
+      bash -c 'while !</dev/tcp/db-api-pgd/5432; do echo "Waiting for database to start..."; sleep 1; done; uvicorn api:app --host 0.0.0.0 --port 5057 --reload'
     ports:
       - "5057:5057"
     volumes:


### PR DESCRIPTION
O comando modificado no container web faz esperar a porta do Postgres estar aberta.