### PR TITLE
fixes #28: separa as strings de conexão ao banco em um arquivo .env

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,5 +20,9 @@ jobs:
       run: sudo mkdir -p pgadmin_data && sudo chown -R 5050:5050 ./pgadmin_data/
     - name: Run docker-compose
       run: docker-compose up -d
+      env:
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
+        POSTGRES_DB: api_pgd
     - name: run tests
       run: docker exec api-pgd_web_1 /bin/bash -c "pytest tests/"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .vscode
 .bash_history
 .python_history
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,3 @@ RUN \
 RUN chown -R api-pgd:api-pgd ./
 COPY ./ /home/api-pgd
 USER api-pgd
-

--- a/README.md
+++ b/README.md
@@ -40,7 +40,16 @@ gerada.
 4. Criar diretório com permissão correta para persistência do PgAdmin:
 > ```$ sudo mkdir -p pgadmin_data && sudo chown -R 5050:5050 ./pgadmin_data/```
 
-5. Tentar subir os containers:
+5. Criar um arquivo `.env` contendo o nome de usuário, senha e nome do
+   banco a serem utilizados pelo Postgres:
+
+```
+$ echo "POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=api_pgd" > .env
+```
+
+6. Tentar subir os containers:
 > ```$ docker-compose up```
 
 Vai dar um erro de permissão no pgadmin. Quando a mensagem de erro

--- a/admin_tool.py
+++ b/admin_tool.py
@@ -4,9 +4,11 @@ Ferramenta de administração da API-PGD.
 """
 
 # dependências
+import os
 import argparse
 import getpass
 import asyncio
+
 import sqlalchemy as sa
 from sqlalchemy.sql import text as sa_text
 
@@ -164,7 +166,7 @@ if __name__ == "__main__":
         action="store_true"
     )
 
-    engine = sa.create_engine("postgresql://postgres:postgres@db-api-pgd:5432/api_pgd")
+    engine = sa.create_engine(os.environ['SQLALCHEMY_DATABASE_URL'])
 
     args = parser.parse_args()
 

--- a/database.py
+++ b/database.py
@@ -1,8 +1,10 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@db-api-pgd:5432/api_pgd"
+SQLALCHEMY_DATABASE_URL = os.environ['SQLALCHEMY_DATABASE_URL']
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   db-api-pgd:
     image: postgres:11
     ports:
-      - "5432:5432"
+      - "5432"
     volumes:
         - ./database:/var/lib/postgresql
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=api_pgd
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
   web:
     image: api-pgd:latest
     command:
@@ -22,6 +22,8 @@ services:
     depends_on:
       - db-api-pgd
     build: ./
+    environment:
+      - SQLALCHEMY_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db-api-pgd:5432/${POSTGRES_DB}
   pgadmin:
     container_name: pgadmin
     image: dpage/pgadmin4


### PR DESCRIPTION
O nome de usuário, senha e nome do banco agora são passados como variáveis de ambiente. Para executar no `docker-compose`, é necessário criar um arquivo `.env`, informando esses parâmetros, conforme explicado no `README.md`.