### PR TITLE
inclui o campo situacao no plano de trabalho

### DIFF
--- a/api.py
+++ b/api.py
@@ -25,7 +25,7 @@ with open('docs/description.md', 'r') as f:
 app = FastAPI(
     title="Plataforma de recebimento de dados do Programa de Gestão - PGD",
     description=description,
-    version="0.1.0",
+    version="0.1.1",
 )
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/jwt/login")

--- a/models.py
+++ b/models.py
@@ -12,6 +12,7 @@ class PlanoTrabalho(Base):
     "Plano de Trabalho"
     __tablename__ = "plano_trabalho"
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    situacao = Column(String)
     cod_unidade = Column(Integer, nullable=False)
     cod_plano = Column(String, nullable=False)
     matricula_siape = Column(Integer)

--- a/schemas.py
+++ b/schemas.py
@@ -96,7 +96,17 @@ class PlanoTrabalhoSchema(BaseModel):
         title="código do Plano de Trabalho",
         description="Identificador único do Plano de Trabalho."
         )
-    situacao: Optional[str] = Field(title="situação do plano")
+    situacao: Optional[str] = Field(
+        title="situação do plano",
+        description="A situação do plano de trabalho.\n"
+            "\n"
+            "O preenchimento do campo é opcional, podendo ser utilizado, "
+            "por exemplo, quando o plano de trabalho for cancelado.\n"
+            "\n"
+            "Valores sugeridos:\n"
+            "* null\n"
+            "* 'cancelado'\n"
+        )
     matricula_siape: int = Field(
         title="Matrícula SIAPE",
         description="Matrícula SIAPE do participante."

--- a/schemas.py
+++ b/schemas.py
@@ -96,6 +96,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="código do Plano de Trabalho",
         description="Identificador único do Plano de Trabalho."
         )
+    situacao: Optional[str] = Field(title="situação do plano")
     matricula_siape: int = Field(
         title="Matrícula SIAPE",
         description="Matrícula SIAPE do participante."
@@ -242,6 +243,7 @@ class PlanoTrabalhoUpdateSchema(BaseModel):
     """Esquema para atualização do plano de trabalho. Na atualização,
     todos os campos são opcionais, exceto cod_plano."""
     cod_plano: str
+    situacao: Optional[str]
     matricula_siape: Optional[int]
     cpf: Optional[str]
     nome_participante: Optional[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def client() -> Generator[Session, None, None]:
 def input_pt() -> dict:
     pt_json = {
         "cod_plano": "555",
+        "situacao": "string",
         "matricula_siape": 0,
         "cpf": "99160773120",
         "nome_participante": "string",

--- a/tests/plano_trabalho_test.py
+++ b/tests/plano_trabalho_test.py
@@ -13,6 +13,7 @@ import pytest
 
 fields_plano_trabalho = {
     "optional": (
+        ["situacao"],
         ["data_interrupcao"],
         ["data_interrupcao", "entregue_no_prazo"],
         ["entregue_no_prazo"],


### PR DESCRIPTION
Os testes estão passando e esta alteração já pode ser incorporada.

@henrique-prog, gostaria de incluir uma descrição para o campo `situacao`? Talvez definir quais são os valores aceitos, ou pelo menos sugeridos? Ou é para deixar livre, mesmo? Por enquanto, está livre e o preenchimento do campo é opcional.
