### PR TITLE
Expõe novamente o método users na documentação swagger

### DIFF
--- a/api.py
+++ b/api.py
@@ -245,7 +245,6 @@ def public_facing_openapi():
     )
     paths = openapi_schema["paths"]
     del paths["/truncate_pts_atividades"]
-    del paths["/users/{id}"]
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 


### PR DESCRIPTION
Conforme solicitado pela gestão do sistema, os métodos `user` serão novamente expostos.

![api-pgd-users](https://user-images.githubusercontent.com/1058414/140402681-2ee290aa-caee-4284-9645-b2d469c9b8ff.png)
