### PR TITLE
Implement running CI script after waiting for db

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,4 +28,4 @@ jobs:
         POSTGRES_PASSWORD: postgres
         POSTGRES_DB: api_pgd
     - name: run tests
-      run: docker exec api-pgd_web_1 /bin/bash -c "pytest tests/"
+      run: docker exec api-pgd_web_1 /bin/bash -c "./run_after_db.py \"pytest tests/\""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   web:
     image: api-pgd:latest
     command:
-      python bootstrap_app.py
+      ./run_after_db.py "uvicorn api:app --host 0.0.0.0 --port 5057 --reload"
     ports:
       - "5057:5057"
     volumes:

--- a/run_after_db.py
+++ b/run_after_db.py
@@ -4,12 +4,22 @@ database to be up and running.
 """
 import os
 import time
+import argparse
 
 import sqlalchemy as sa
 from sqlalchemy.exc import OperationalError
 
 MAX_RETRIES = 120
-CMD = 'uvicorn api:app --host 0.0.0.0 --port 5057 --reload'
+
+parser = argparse.ArgumentParser(description=
+    'Wait for the database to be responsive and then runs a command.')
+parser.add_argument(
+    'command_line',
+    nargs='+',
+    help=('The command to run after the database is online. '
+        'Please encase the command in quotes.'))
+args = parser.parse_args()
+command = ' '.join(args.command_line) # pylint: disable=invalid-name
 
 engine = sa.create_engine(os.environ['SQLALCHEMY_DATABASE_URL'])
 
@@ -23,4 +33,5 @@ for _ in range(MAX_RETRIES):
         print('Postgres database unavailable, waiting...')
     time.sleep(1)
 
-os.system(CMD)
+print('Executing command: ', command)
+os.system(command)


### PR DESCRIPTION
Added a generic Python script that will wait the the database to be online and then run any command afterward.

This is used both for starting the application as well as running the CI tests.

Fixes #60