### PR TITLE
Implements redirection based on http conneg

### DIFF
--- a/tests/entrypoint_test.py
+++ b/tests/entrypoint_test.py
@@ -4,11 +4,26 @@ Testes relacionados com acessos aos endpoints.
 
 from requests import Session
 from fastapi import status
+import pytest
 
-def test_redirect_to_docs(client: Session):
+def test_redirect_to_docs_html(client: Session):
     """
-    Testa se o acesso na raiz redireciona para o /docs.
+    Testa se o acesso por um navegador na raiz redireciona para o /docs.
     """
-    response = client.get("/", allow_redirects=False)
-    assert response.status_code == status.HTTP_301_MOVED_PERMANENTLY
+    response = client.get("/",
+        allow_redirects=False,
+        headers={"Accept": "text/html"})
+
+    assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     assert response.headers['Location'] == "/docs"
+
+def test_redirect_to_entrypoint_json(client: Session):
+    """
+    Testa se o acesso por um script na raiz redireciona para o /openapi.json.
+    """
+    response = client.get("/",
+        allow_redirects=False,
+        headers={"Accept": "application/json"})
+
+    assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert response.headers['Location'] == "/openapi.json"


### PR DESCRIPTION
Access to the root (`.`) will redirect to a different url depending on content negotiation. Browsers requesting html will be redirected to `/docs`, scripts requesting json will be redirected to `/openapi.json`.

Fixes #61